### PR TITLE
add full python path doted notation for non-nose tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ in the menu), and change it to looks like this:
             "django-nose-test": {
                 "python": "/path/to/your/virtualenv/bin/python",
                 "django-settings": "myproject.settings.test",
+                "doted-notation": true,  // optional and only used if "use-nose" is false
                 "use-nose": true,
                 "nose-options": ["--nocapture"] // optional and only used if use-nose is true
             }
@@ -44,6 +45,8 @@ in the menu), and change it to looks like this:
     }
 
 The `django-nose-test` dictionary are the settings for DjangoNoseTestRunner.
+
+The `doted-notation` required for Django 1.6 or [django-discover-runner](https://github.com/jezdez/django-discover-runner).
 
 ## Usage
 

--- a/djangotest.py
+++ b/djangotest.py
@@ -95,14 +95,20 @@ class DjangoNoseTestCommand(sublime_plugin.TextCommand):
 
         nose_options = settings.get('nose-options', [])
 
+        doted_notation = settings.get('doted-notation', [])
+
         if regions != []:
             for r in regions:
                 if use_nose:
                     cmd.append('%s:%s' % (file_python_path, r))
+                elif doted_notation:
+                    cmd.append('%s.%s' % (file_python_path, r))
                 else:
                     cmd.append('%s.%s' % (app_name, r))
         else:
             if use_nose:
+                cmd.append(file_python_path)
+            elif doted_notation:
                 cmd.append(file_python_path)
             else:
                 cmd.append(app_name)


### PR DESCRIPTION
Add capability to use with Django 1.6 projects and [django-discover-runner](https://github.com/jezdez/django-discover-runner)
