### PR TITLE
Not running single test problem.

### DIFF
--- a/djangotest.py
+++ b/djangotest.py
@@ -3,6 +3,7 @@ import sublime
 import re
 import os.path
 
+SUBLIME_2_VERSION = 2221
 
 class DjangoNoseTestCommand(sublime_plugin.TextCommand):
 
@@ -156,8 +157,12 @@ class DjangoNoseTestCommand(sublime_plugin.TextCommand):
 
         lines = self.get_lines()
 
+        region_class_name = 'entity.name.type.class'
+        if int(sublime.version()) > SUBLIME_2_VERSION:
+            region_class_name = 'entity.name.class'
+
         cls_regions = self.filter_selected_regions(
-            self.get_regions('entity.name.type.class'), lines)
+            self.get_regions(region_class_name), lines)
 
         fn_regions = self.filter_selected_regions(
             self.get_regions('meta.function'), lines)


### PR DESCRIPTION
Hi,

I recently installed the plugin in Sublime 3 and just couldn't run single tests, it would always run the entire module.

Apparently the selector for a `class` in the `find_by_selector` method changed from one version to another. What I did was the simples solution I could come up with, not sure if is the best solution but it's a start.

Thanks for the plugin.

